### PR TITLE
Blob not exist exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ from fsspec.registry import known_implementations
 known_implementations['abfs'] = {'class': 'adlfs.AzureBlobFileSystem'}
 STORAGE_OPTIONS={'account_name': ACCOUNT_NAME, 'account_key': ACCOUNT_KEY}
 
-ddf = dd.read_csv('abfs://{CONTAINER}/{FOLDER}/*.csv', storage_options=STORAGE_OPTIONS}
-ddf = dd.read_csv('abfs://{CONTAINER}/folder.parquet', storage_options=STORAGE_OPTIONS}
+ddf = dd.read_csv('abfs://{CONTAINER}/{FOLDER}/*.csv', storage_options=STORAGE_OPTIONS)
+ddf = dd.read_csv('abfs://{CONTAINER}/folder.parquet', storage_options=STORAGE_OPTIONS)
 ```
 
 Details

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use the Gen2 filesystem:
 ```
 import dask.dataframe as dd
 from fsspec.registry import known_implementations
-known_implementations['abfs'] = {'class': 'adlfs.AzureDatalakeFileSystem'}
+known_implementations['abfs'] = {'class': 'adlfs.AzureBlobFileSystem'}
 STORAGE_OPTIONS={'account_name': ACCOUNT_NAME, 'account_key': ACCOUNT_KEY}
 
 ddf = dd.read_csv('abfs://{CONTAINER}/{FOLDER}/*.csv', storage_options=STORAGE_OPTIONS}

--- a/adlfs/tests/conftest.py
+++ b/adlfs/tests/conftest.py
@@ -18,13 +18,13 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def host(request):
     print("host:", request.config.getoption("--host"))
     return request.config.getoption("--host")
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def storage(host):
     """
     Create blob using azurite.
@@ -38,4 +38,6 @@ def storage(host):
 
     bbs.create_blob_from_bytes("data", "root/a/file.txt", data)
     bbs.create_blob_from_bytes("data", "root/b/file.txt", data)
+    bbs.create_blob_from_bytes("data", "root/c/file1.txt", data)
+    bbs.create_blob_from_bytes("data", "root/c/file2.txt", data)
     yield bbs

--- a/adlfs/tests/test_core.py
+++ b/adlfs/tests/test_core.py
@@ -12,7 +12,6 @@ def test_connect(storage):
     )
 
 
-@pytest.mark.xfail(reason="buggy implementation?")
 def test_ls(storage):
     fs = adlfs.AzureBlobFileSystem(
         storage.account_name,
@@ -20,8 +19,65 @@ def test_ls(storage):
         storage.account_key,
         custom_domain=f"http://{storage.primary_endpoint}",
     )
-    assert fs.ls("/") == ["root"]
-    assert fs.ls("/root/a/") == ["file.txt"]
+    assert fs.ls("") == ["root/a/", "root/b/", "root/c/"]
+    assert fs.ls("root/") == ["root/a/", "root/b/", "root/c/"]
+    assert fs.ls("root") == ["root/a/", "root/b/", "root/c/"]
+    assert fs.ls("root/a/") == ["root/a/file.txt"]
+    assert fs.ls("root/a") == ["root/a/file.txt"]
+
+    assert fs.ls("root/a/file.txt", detail=True) == [
+        {
+            "name": "root/a/file.txt",
+            "size": 10,
+            "container_name": "data",
+            "type": "file",
+        }
+    ]
+    assert fs.ls("root/a", detail=True) == [
+        {
+            "name": "root/a/file.txt",
+            "size": 10,
+            "container_name": "data",
+            "type": "file",
+        }
+    ]
+    assert fs.ls("root/a/", detail=True) == [
+        {
+            "name": "root/a/file.txt",
+            "size": 10,
+            "container_name": "data",
+            "type": "file",
+        }
+    ]
+
+
+def test_info(storage):
+    fs = adlfs.AzureBlobFileSystem(
+        storage.account_name,
+        "data",
+        storage.account_key,
+        custom_domain=f"http://{storage.primary_endpoint}",
+    )
+    assert fs.info("root/a/file.txt")["name"] == "root/a/file.txt"
+    assert fs.info("root/a/file.txt")["container_name"] == "data"
+    assert fs.info("root/a/file.txt")["type"] == "file"
+    assert fs.info("root/a/file.txt")["size"] == 10
+    # assert fs.info('root/a')['container_name'] == 'data'
+
+
+def test_glob(storage):
+    fs = adlfs.AzureBlobFileSystem(
+        storage.account_name,
+        "data",
+        storage.account_key,
+        custom_domain=f"http://{storage.primary_endpoint}",
+    )
+    assert fs.glob("root/a/file.txt") == ["root/a/file.txt"]
+    assert fs.glob("root/a/") == ["root/a/file.txt"]
+    assert fs.glob("root/a") == ["root/a"]
+    assert fs.glob("root/") == ["root/a", "root/b", "root/c"]
+    assert fs.glob("root/*") == ["root/a", "root/b", "root/c"]
+    assert fs.glob("root/c/*.txt") == ["root/c/file1.txt", "root/c/file2.txt"]
 
 
 def test_open_file(storage):


### PR DESCRIPTION
Includes fixes to the glob method, which eliminates some errors encountered when reading sharded parquet or csv files.  Additional syntax fixes for the README.md file.