### PR TITLE
Treat container name as directory

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -500,7 +500,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
 
     def rmdir(self, path, delimiter='/'):
         container_name, path = self.split_path(path, delimiter=delimiter)
-        if (container_name in self.ls('')) and (not path):
+        if (container_name+delimiter in self.ls('')) and (not path):
             # delete container
             self.blob_fs.delete_container(container_name)
 
@@ -512,7 +512,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
             self.blob_fs.delete_blob(container_name, path)
         elif self.isdir(path):
             container_name, path = self.split_path(path, delimiter=delimiter)
-            if (container_name in self.ls('')) and (not path):
+            if (container_name+delimiter in self.ls('')) and (not path):
                 logging.debug(f'Delete container {container_name}')
                 self.blob_fs.delete_container(container_name)
         else:

--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -511,6 +511,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
             logging.debug(f'Delete blob {path} in {container_name}')
             self.blob_fs.delete_blob(container_name, path)
         elif self.isdir(path):
+            container_name, path = self.split_path(path, delimiter=delimiter)
             if (container_name in self.ls('')) and (not path):
                 logging.debug(f'Delete container {container_name}')
                 self.blob_fs.delete_container(container_name)

--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -7,12 +7,12 @@ from os.path import join
 
 from azure.datalake.store import lib, AzureDLFileSystem
 from azure.datalake.store.core import AzureDLPath, AzureDLFile
-from azure.storage.blob import BlockBlobService, BlobPrefix, Container, Blob
+from azure.storage.blob import BlockBlobService, BlobPrefix, Container
 from azure.storage.common._constants import SERVICE_HOST_BASE, DEFAULT_PROTOCOL
 from fsspec import AbstractFileSystem
 from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import infer_storage_options
-from fsspec.utils import stringify_path, tokenize
+from fsspec.utils import tokenize
 
 logger = logging.getLogger(__name__)
 

--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -423,14 +423,14 @@ class AzureBlobFileSystem(AbstractFileSystem):
             if detail:
                 return self._details(contents)
             else:
-                return [c.name for c in contents]
+                return [c.name+'/' for c in contents]
 
         else:
             container_name, path = self.split_path(path)
 
             # show all top-level prefixes (directories) and files
             if not path:
-                if container_name not in self.ls(''):
+                if container_name+'/' not in self.ls(''):
                     raise FileNotFoundError(container_name)
 
                 logging.debug(f'{path} appears to be a container')
@@ -469,7 +469,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
             if container_name:
                 data["name"] = join(container_name, c.name)
             else:
-                data["name"] = c.name
+                data["name"] = c.name+'/'
 
             if isinstance(c, BlobPrefix):
                 data["type"] = "directory"

--- a/adlfs/tests/conftest.py
+++ b/adlfs/tests/conftest.py
@@ -36,6 +36,8 @@ def storage(host):
     )
     bbs.create_container("data", timeout=1)
 
+    bbs.create_blob_from_bytes("data", "top_file.txt", data)
+    bbs.create_blob_from_bytes("data", "root/rfile.txt", data)
     bbs.create_blob_from_bytes("data", "root/a/file.txt", data)
     bbs.create_blob_from_bytes("data", "root/b/file.txt", data)
     bbs.create_blob_from_bytes("data", "root/c/file1.txt", data)

--- a/adlfs/tests/test_core.py
+++ b/adlfs/tests/test_core.py
@@ -18,7 +18,6 @@ def spawn_azurite():
 def test_connect(storage):
     adlfs.AzureBlobFileSystem(
         storage.account_name,
-        "data",
         storage.account_key,
         custom_domain=f"http://{storage.primary_endpoint}",
     )
@@ -27,81 +26,135 @@ def test_connect(storage):
 def test_ls(storage):
     fs = adlfs.AzureBlobFileSystem(
         storage.account_name,
-        "data",
         storage.account_key,
         custom_domain=f"http://{storage.primary_endpoint}",
     )
-    assert fs.ls("") == ["root/a/", "root/b/", "root/c/"]
-    assert fs.ls("root/") == ["root/a/", "root/b/", "root/c/"]
-    assert fs.ls("root") == ["root/a/", "root/b/", "root/c/"]
-    assert fs.ls("root/a/") == ["root/a/file.txt"]
-    assert fs.ls("root/a") == ["root/a/file.txt"]
 
-    assert fs.ls("root/a/file.txt", detail=True) == [
+    ## these are containers
+    assert fs.ls("") == ["data/"]
+    assert fs.ls("/") == ["data/"]
+
+    ## these are top-level directories and files
+    assert fs.ls("data") == ["data/root/", "data/top_file.txt"]
+    assert fs.ls("/data") == ["data/root/", "data/top_file.txt"]
+
+    ## root contains files and directories
+    assert fs.ls("data/root") == ["data/root/a/", "data/root/b/", "data/root/c/", "data/root/rfile.txt"]
+    assert fs.ls("data/root/") == ["data/root/a/", "data/root/b/", "data/root/c/", "data/root/rfile.txt"]
+
+    ## slashes are not not needed, but accepted
+    assert fs.ls("data/root/a") == ["data/root/a/file.txt"]
+    assert fs.ls("data/root/a/") == ["data/root/a/file.txt"]
+    assert fs.ls("/data/root/a") == ["data/root/a/file.txt"]
+    assert fs.ls("/data/root/a/") == ["data/root/a/file.txt"]
+
+    ## file details
+    assert fs.ls("data/root/a/file.txt", detail=True) == [
         {
-            "name": "root/a/file.txt",
+            "name": "data/root/a/file.txt",
             "size": 10,
-            "container_name": "data",
             "type": "file",
         }
     ]
-    assert fs.ls("root/a", detail=True) == [
+
+    ## c has two files
+    assert fs.ls("data/root/c", detail=True) == [
         {
-            "name": "root/a/file.txt",
+            "name": "data/root/c/file1.txt",
             "size": 10,
-            "container_name": "data",
+            "type": "file",
+        },
+        {
+            "name": "data/root/c/file2.txt",
+            "size": 10,
             "type": "file",
         }
     ]
-    assert fs.ls("root/a/", detail=True) == [
-        {
-            "name": "root/a/file.txt",
-            "size": 10,
-            "container_name": "data",
-            "type": "file",
-        }
-    ]
+
+    ## if not direct match is found throws error
+    with pytest.raises(FileNotFoundError):
+        fs.ls('not-a-container')
+
+    with pytest.raises(FileNotFoundError):
+        fs.ls('data/not-a-directory/')
+
+    with pytest.raises(FileNotFoundError):
+        fs.ls('data/root/not-a-file.txt')
 
 
 def test_info(storage):
     fs = adlfs.AzureBlobFileSystem(
         storage.account_name,
-        "data",
         storage.account_key,
         custom_domain=f"http://{storage.primary_endpoint}",
     )
-    assert fs.info("root/a/file.txt")["name"] == "root/a/file.txt"
-    assert fs.info("root/a/file.txt")["container_name"] == "data"
-    assert fs.info("root/a/file.txt")["type"] == "file"
-    assert fs.info("root/a/file.txt")["size"] == 10
 
+    container_info = fs.info('data')
+    assert container_info == {
+        "name":'data/',
+        "type": 'directory',
+        'size': 0
+    }
 
-# assert fs.info('root/a')['container_name'] == 'data'
+    dir_info = fs.info('data/root/c')
+    assert dir_info == {
+        "name":'data/root/c/',
+        "type": 'directory',
+        'size': 0
+    }
+    file_info = fs.info('data/root/a/file.txt')
+    assert file_info == {
+        "name":'data/root/a/file.txt',
+        "type": 'file',
+        'size': 10
+    }
 
 
 def test_glob(storage):
     fs = adlfs.AzureBlobFileSystem(
         storage.account_name,
-        "data",
         storage.account_key,
         custom_domain=f"http://{storage.primary_endpoint}",
     )
-    assert fs.glob("root/a/file.txt") == ["root/a/file.txt"]
-    assert fs.glob("root/a/") == ["root/a/file.txt"]
-    assert fs.glob("root/a") == ["root/a"]
-    assert fs.glob("root/") == ["root/a", "root/b", "root/c"]
-    assert fs.glob("root/*") == ["root/a", "root/b", "root/c"]
-    assert fs.glob("root/c/*.txt") == ["root/c/file1.txt", "root/c/file2.txt"]
+
+    ## just the directory name
+    assert fs.glob("data/root") == ["data/root"]
+    ## top-level contents of a directory
+    assert fs.glob('data/root/') == ['data/root/a', 'data/root/b', 'data/root/c', 'data/root/rfile.txt']
+    assert fs.glob('data/root/*') == ['data/root/a', 'data/root/b', 'data/root/c', 'data/root/rfile.txt']
+
+    assert fs.glob('data/root/b/*') == ['data/root/b/file.txt']
+
+    ## across directories
+    assert fs.glob('data/root/*/file.txt') == ['data/root/a/file.txt', 'data/root/b/file.txt']
+
+    ## regex match
+    assert fs.glob('data/root/*/file[0-9].txt') == ['data/root/c/file1.txt', 'data/root/c/file2.txt']
+    
+    ## text files
+    assert fs.glob('data/root/*/file*.txt') == ['data/root/a/file.txt',
+                                                'data/root/b/file.txt',
+                                                'data/root/c/file1.txt',
+                                                'data/root/c/file2.txt']
+
+    ## all text files
+    assert fs.glob('data/**/*.txt') == ['data/root/a/file.txt',
+                                        'data/root/b/file.txt',
+                                        'data/root/c/file1.txt',
+                                        'data/root/c/file2.txt',
+                                        'data/root/rfile.txt']
+    
+    ## missing
+    assert fs.glob('data/missing/*') == []
 
 
 def test_open_file(storage):
     fs = adlfs.AzureBlobFileSystem(
         storage.account_name,
-        "data",
         storage.account_key,
         custom_domain=f"http://{storage.primary_endpoint}",
     )
-    f = fs.open("/root/a/file.txt")
+    f = fs.open("/data/root/a/file.txt")
 
     result = f.read()
     assert result == b"0123456789"

--- a/adlfs/tests/test_core.py
+++ b/adlfs/tests/test_core.py
@@ -39,8 +39,18 @@ def test_ls(storage):
     assert fs.ls("/data") == ["data/root/", "data/top_file.txt"]
 
     ## root contains files and directories
-    assert fs.ls("data/root") == ["data/root/a/", "data/root/b/", "data/root/c/", "data/root/rfile.txt"]
-    assert fs.ls("data/root/") == ["data/root/a/", "data/root/b/", "data/root/c/", "data/root/rfile.txt"]
+    assert fs.ls("data/root") == [
+        "data/root/a/",
+        "data/root/b/",
+        "data/root/c/",
+        "data/root/rfile.txt",
+    ]
+    assert fs.ls("data/root/") == [
+        "data/root/a/",
+        "data/root/b/",
+        "data/root/c/",
+        "data/root/rfile.txt",
+    ]
 
     ## slashes are not not needed, but accepted
     assert fs.ls("data/root/a") == ["data/root/a/file.txt"]
@@ -50,36 +60,24 @@ def test_ls(storage):
 
     ## file details
     assert fs.ls("data/root/a/file.txt", detail=True) == [
-        {
-            "name": "data/root/a/file.txt",
-            "size": 10,
-            "type": "file",
-        }
+        {"name": "data/root/a/file.txt", "size": 10, "type": "file"}
     ]
 
     ## c has two files
     assert fs.ls("data/root/c", detail=True) == [
-        {
-            "name": "data/root/c/file1.txt",
-            "size": 10,
-            "type": "file",
-        },
-        {
-            "name": "data/root/c/file2.txt",
-            "size": 10,
-            "type": "file",
-        }
+        {"name": "data/root/c/file1.txt", "size": 10, "type": "file"},
+        {"name": "data/root/c/file2.txt", "size": 10, "type": "file"},
     ]
 
     ## if not direct match is found throws error
     with pytest.raises(FileNotFoundError):
-        fs.ls('not-a-container')
+        fs.ls("not-a-container")
 
     with pytest.raises(FileNotFoundError):
-        fs.ls('data/not-a-directory/')
+        fs.ls("data/not-a-directory/")
 
     with pytest.raises(FileNotFoundError):
-        fs.ls('data/root/not-a-file.txt')
+        fs.ls("data/root/not-a-file.txt")
 
 
 def test_info(storage):
@@ -89,25 +87,13 @@ def test_info(storage):
         custom_domain=f"http://{storage.primary_endpoint}",
     )
 
-    container_info = fs.info('data')
-    assert container_info == {
-        "name":'data/',
-        "type": 'directory',
-        'size': 0
-    }
+    container_info = fs.info("data")
+    assert container_info == {"name": "data/", "type": "directory", "size": 0}
 
-    dir_info = fs.info('data/root/c')
-    assert dir_info == {
-        "name":'data/root/c/',
-        "type": 'directory',
-        'size': 0
-    }
-    file_info = fs.info('data/root/a/file.txt')
-    assert file_info == {
-        "name":'data/root/a/file.txt',
-        "type": 'file',
-        'size': 10
-    }
+    dir_info = fs.info("data/root/c")
+    assert dir_info == {"name": "data/root/c/", "type": "directory", "size": 0}
+    file_info = fs.info("data/root/a/file.txt")
+    assert file_info == {"name": "data/root/a/file.txt", "type": "file", "size": 10}
 
 
 def test_glob(storage):
@@ -120,32 +106,52 @@ def test_glob(storage):
     ## just the directory name
     assert fs.glob("data/root") == ["data/root"]
     ## top-level contents of a directory
-    assert fs.glob('data/root/') == ['data/root/a', 'data/root/b', 'data/root/c', 'data/root/rfile.txt']
-    assert fs.glob('data/root/*') == ['data/root/a', 'data/root/b', 'data/root/c', 'data/root/rfile.txt']
+    assert fs.glob("data/root/") == [
+        "data/root/a",
+        "data/root/b",
+        "data/root/c",
+        "data/root/rfile.txt",
+    ]
+    assert fs.glob("data/root/*") == [
+        "data/root/a",
+        "data/root/b",
+        "data/root/c",
+        "data/root/rfile.txt",
+    ]
 
-    assert fs.glob('data/root/b/*') == ['data/root/b/file.txt']
+    assert fs.glob("data/root/b/*") == ["data/root/b/file.txt"]
 
     ## across directories
-    assert fs.glob('data/root/*/file.txt') == ['data/root/a/file.txt', 'data/root/b/file.txt']
+    assert fs.glob("data/root/*/file.txt") == [
+        "data/root/a/file.txt",
+        "data/root/b/file.txt",
+    ]
 
     ## regex match
-    assert fs.glob('data/root/*/file[0-9].txt') == ['data/root/c/file1.txt', 'data/root/c/file2.txt']
-    
+    assert fs.glob("data/root/*/file[0-9].txt") == [
+        "data/root/c/file1.txt",
+        "data/root/c/file2.txt",
+    ]
+
     ## text files
-    assert fs.glob('data/root/*/file*.txt') == ['data/root/a/file.txt',
-                                                'data/root/b/file.txt',
-                                                'data/root/c/file1.txt',
-                                                'data/root/c/file2.txt']
+    assert fs.glob("data/root/*/file*.txt") == [
+        "data/root/a/file.txt",
+        "data/root/b/file.txt",
+        "data/root/c/file1.txt",
+        "data/root/c/file2.txt",
+    ]
 
     ## all text files
-    assert fs.glob('data/**/*.txt') == ['data/root/a/file.txt',
-                                        'data/root/b/file.txt',
-                                        'data/root/c/file1.txt',
-                                        'data/root/c/file2.txt',
-                                        'data/root/rfile.txt']
-    
+    assert fs.glob("data/**/*.txt") == [
+        "data/root/a/file.txt",
+        "data/root/b/file.txt",
+        "data/root/c/file1.txt",
+        "data/root/c/file2.txt",
+        "data/root/rfile.txt",
+    ]
+
     ## missing
-    assert fs.glob('data/missing/*') == []
+    assert fs.glob("data/missing/*") == []
 
 
 def test_open_file(storage):
@@ -180,21 +186,21 @@ def test_mkdir_rmdir(storage):
         custom_domain=f"http://{storage.primary_endpoint}",
     )
 
-    fs.mkdir('new-container')
-    assert 'new-container/' in fs.ls('')
+    fs.mkdir("new-container")
+    assert "new-container/" in fs.ls("")
 
-    with fs.open('new-container/file.txt', 'wb') as f:
-        f.write(b'0123456789')
-    
-    with fs.open('new-container/dir/file.txt', 'wb') as f:
-        f.write(b'0123456789')
-    with fs.open('new-container/dir/file.txt', 'wb') as f:
-        f.write(b'0123456789')
-    
-    fs.rm('new-container/dir', recursive=True)
-    assert fs.ls('new-container') == ['new-container/file.txt']
+    with fs.open("new-container/file.txt", "wb") as f:
+        f.write(b"0123456789")
 
-    fs.rm('new-container/file.txt')
-    fs.rmdir('new-container')
+    with fs.open("new-container/dir/file.txt", "wb") as f:
+        f.write(b"0123456789")
+    with fs.open("new-container/dir/file.txt", "wb") as f:
+        f.write(b"0123456789")
 
-    assert 'new-container/' not in fs.ls('')
+    fs.rm("new-container/dir", recursive=True)
+    assert fs.ls("new-container") == ["new-container/file.txt"]
+
+    fs.rm("new-container/file.txt")
+    fs.rmdir("new-container")
+
+    assert "new-container/" not in fs.ls("")


### PR DESCRIPTION
To begin with, a few issues were identified in version 0.1.5

* ls would not reliably list files in the top-level of a container (not in a subirectory)
* ls would not reliably list some files deeply nested in subdirectories
* ls would only return ~3000 files from a directory known to contain 31,000 files
* Reading an Intake catalog stored on Azure would throw errors
    * `"Collision between inferred and specified storage options:\n- 'container_name'"`
    * This was the motivating factor for treating containers as directories since the `.walk()` routine would get very confused.
    * see below for more details

Taking inspiration from [s3fs](https://s3fs.readthedocs.io/en/latest/) I propose treating the leading directory name as the container name. This allows a single FS object to access data across multiple containers.

During this effort I discovered that I only needed to implement `.ls()`. Everything else is derived from it, like `.glob()`, `.walk()`, and `.info()`.

## New behavior

To instantiate, just pass storage options.

```python
import fsspec
fs = fsspec.filesystem('abfs', is_emulated=True)
```

Using the blobs defined in the updated tests as an example the following scenarios are provided in this PR

```python
    data = b'0123456789'
    bbs.create_container("data",)

    bbs.create_blob_from_bytes("data", "top_file.txt", data)
    bbs.create_blob_from_bytes("data", "root/rfile.txt", data)
    bbs.create_blob_from_bytes("data", "root/a/file.txt", data)
    bbs.create_blob_from_bytes("data", "root/b/file.txt", data)
    bbs.create_blob_from_bytes("data", "root/c/file1.txt", data)
    bbs.create_blob_from_bytes("data", "root/c/file2.txt", data)
```

* `fs.ls('')` or `fs.ls('/')` returns the list of accessible containers to account name
    * `['data/']`
* `fs.ls('<container-name>')` will return both subdirectories (prefixes) and files (blobs)
    * `['data/root/', 'data/top_file.txt']`
    * this behavior maintains through all levels of subdirectories ('data/root/' is a directory)
* `fs.ls()` will utilize the bbs.list_blobs().next_marker (see _generate_blobs) value to read *all* files in a subdirectory or container

## New methods

* `fs.rm(<path-to-file>)` will delete files and use `recursive=True` to remove subdirectories
* `fs.mkdir(<container>)` will create a new container
* `fs.rmdir(<container>)` will delete containers



## Intake catalog structure

Starting with the last issue our catalog is stored at `<container-name>/<sub-dir>/catalog.yml` and the parquet files are stored in nested subirectories at `<container-name>/<sub-dir>/data.parquet`. Here's the catalog.yml file

```yaml

sources:
  big_data:
    args:
      engine: pyarrow
      urlpath: '{{ CATALOG_DIR }}/data.parquet'
    description: Partitioned file written with PyArrow
    driver: parquet
```

I then read the catalog as

```python
import intake
catalog = intake.open_catalog(f'abfs://<container-name>/<sub-dir>/catalog.yml',
                              storage_options=STORAGE_OPTIONS)

df = catalog.big_data.to_dask()
```

In version 0.1.5 the `<container-name>` would get stripped from the path at the level where Intake reads the catalog. Adlfs would then attempt to infer `<sub-dir>` as the container name and attempt to merge that with the inherited `<container-name>`, which lead to the collision.