### PR TITLE
Fix for "KeyError: 'type' using fs.glob" #34

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -403,7 +403,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
                         logging.debug(f"Handling AttributeError for {blob.name}")
                         logging.debug(f"")
                         if path == blob.name.rstrip("/"):
-                            self.ls(blob.name, detail=detail, delimiter=None)
+                            return self.ls(blob.name, detail=detail, delimiter=None)
                         elif isinstance(blob, BlobPrefix):
                             data["type"] = "directory"
                             data["size"] = 0


### PR DESCRIPTION
Add return statement to handle folders being the prefix of another folder during ls operations. Fixes #34 for me.

I'm not super familiar with the code, but this fixes my issue and seems like it it was the original intention (as the self.ls seems pointless otherwise).