### PR TITLE
Fix chucked upload incompatibilities with #35

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -595,8 +595,8 @@ class AzureBlobFile(AbstractBufferedFile):
 
     def _initiate_upload(self):
         self._block_list = []
-        if self.fs.blob_fs.exists(self.container_name, self.path):
-            self.fs.blob_fs.delete_blob(self.container_name, self.path)
+        if self.fs.blob_fs.exists(self.container_name, self.blob):
+            self.fs.blob_fs.delete_blob(self.container_name, self.blob)
         return super()._initiate_upload()
 
     def _upload_chunk(self, final=False, **kwargs):
@@ -605,7 +605,7 @@ class AzureBlobFile(AbstractBufferedFile):
         block_id = f"{block_id:07d}"
         self.fs.blob_fs.put_block(
             container_name=self.container_name,
-            blob_name=self.path,
+            blob_name=self.blob,
             block=data,
             block_id=block_id,
         )
@@ -615,6 +615,6 @@ class AzureBlobFile(AbstractBufferedFile):
             block_list = [BlobBlock(_id) for _id in self._block_list]
             self.fs.blob_fs.put_block_list(
                 container_name=self.container_name,
-                blob_name=self.path,
+                blob_name=self.blob,
                 block_list=block_list,
             )

--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
 import logging
 from os.path import join
-
-
 from azure.datalake.store import lib, AzureDLFileSystem
 from azure.datalake.store.core import AzureDLPath, AzureDLFile
-from azure.storage.blob import BlockBlobService, BlobPrefix, Container
+from azure.storage.blob import BlockBlobService, BlobPrefix, Container, BlobBlock
 from azure.storage.common._constants import SERVICE_HOST_BASE, DEFAULT_PROTOCOL
 from fsspec import AbstractFileSystem
 from fsspec.spec import AbstractBufferedFile
@@ -269,6 +267,9 @@ class AzureBlobFileSystem(AbstractFileSystem):
     token_credential:
         A token credential used to authenticate HTTPS requests. The token value
         should be updated before its expiration.
+    blocksize:
+        The block size to use for download/upload operations. Defaults to the value of
+        ``BlockBlobService.MAX_BLOCK_SIZE``
 
     Examples
     --------
@@ -299,6 +300,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
         connection_string: str = None,
         socket_timeout=None,
         token_credential=None,
+        blocksize=BlockBlobService.MAX_BLOCK_SIZE,
     ):
         AbstractFileSystem.__init__(self)
         self.account_name = account_name
@@ -312,6 +314,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
         self.connection_string = connection_string
         self.socket_timeout = socket_timeout
         self.token_credential = token_credential
+        self.blocksize = blocksize
         self.do_connect()
 
     @classmethod
@@ -545,7 +548,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
             fs=self,
             path=path,
             mode=mode,
-            block_size=block_size,
+            block_size=block_size or self.blocksize,
             autocommit=autocommit,
             cache_options=cache_options,
             **kwargs,
@@ -590,8 +593,28 @@ class AzureBlobFile(AbstractBufferedFile):
         )
         return blob.content
 
+    def _initiate_upload(self):
+        self._block_list = []
+        if self.fs.blob_fs.exists(self.container_name, self.path):
+            self.fs.blob_fs.delete_blob(self.container_name, self.path)
+        return super()._initiate_upload()
+
     def _upload_chunk(self, final=False, **kwargs):
         data = self.buffer.getvalue()
-        self.fs.blob_fs.create_blob_from_bytes(
-            container_name=self.container_name, blob_name=self.blob, blob=data
+        block_id = len(self._block_list)
+        block_id = f"{block_id:07d}"
+        self.fs.blob_fs.put_block(
+            container_name=self.container_name,
+            blob_name=self.path,
+            block=data,
+            block_id=block_id,
         )
+        self._block_list.append(block_id)
+
+        if final:
+            block_list = [BlobBlock(_id) for _id in self._block_list]
+            self.fs.blob_fs.put_block_list(
+                container_name=self.container_name,
+                blob_name=self.path,
+                block_list=block_list,
+            )


### PR DESCRIPTION
This PR fixes incompatibilities with the introduction of containers as part of the path from #35.

This also add some tests to ensure large blob functionality works.