### PR TITLE
Make DIRECTORY type lower case to be compatible with fsspec walk method

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -99,8 +99,8 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
         )
 
         for file in files:
-            if 'type' in file and file['type'] == 'DIRECTORY':
-                file['type'] = 'directory'
+            if "type" in file and file["type"] == "DIRECTORY":
+                file["type"] = "directory"
 
         return files
 

--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -94,9 +94,15 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
         self.azure_fs = AzureDLFileSystem(token=token, store_name=self.store_name)
 
     def ls(self, path, detail=False, invalidate_cache=True, **kwargs):
-        return self.azure_fs.ls(
+        files = self.azure_fs.ls(
             path=path, detail=detail, invalidate_cache=invalidate_cache
         )
+
+        for file in files:
+            if 'type' in file and file['type'] == 'DIRECTORY':
+                file['type'] = 'directory'
+
+        return files
 
     def info(self, path, invalidate_cache=True, expected_error_code=404, **kwargs):
         info = self.azure_fs.info(


### PR DESCRIPTION
Modification to the adlfs ls method to fix an inconsistency that breaks fsspec walk method. 

Currently the azure-data-lake-store code uses a file type of 'DIRECTORY' whereas fsspec expects a lower case value in the walk method (specifically  `info["type"] == "directory"` in walk method here https://github.com/intake/filesystem_spec/blob/master/fsspec/spec.py)

This change swaps out the uppercase for lowercase value in adlfs ls method. Tested and walk method works with this change