### PR TITLE
Fix mkdir when storage account has hierarchical namespace enabled

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -642,7 +642,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
             if (container_name not in self.ls("")) and (not path):
                 # create new container
                 self.service_client.create_container(name=container_name)
-            elif (container_name in self.ls("")) and path:
+            elif (container_name in [container_path.split("/")[0] for container_path in self.ls("")]) and path:
                 ## attempt to create prefix
                 container_client = self.service_client.get_container_client(
                     container=container_name

--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -642,7 +642,10 @@ class AzureBlobFileSystem(AbstractFileSystem):
             if (container_name not in self.ls("")) and (not path):
                 # create new container
                 self.service_client.create_container(name=container_name)
-            elif (container_name in [container_path.split("/")[0] for container_path in self.ls("")]) and path:
+            elif (
+                container_name
+                in [container_path.split("/")[0] for container_path in self.ls("")]
+            ) and path:
                 ## attempt to create prefix
                 container_client = self.service_client.get_container_client(
                     container=container_name


### PR DESCRIPTION
When storage accounts have hierarchical namespace enabled, the paths returned have a trailing `/` in them

Ex. `ls("")` on the storage account will return
```python3
["abc/", "abc2/"]

```

So the condition on the ls fails in that case