### PR TITLE
Fixed trying to raise a str instead of Exception

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -751,7 +751,7 @@ class AzureBlobFile(AbstractBufferedFile):
         except ResourceNotFoundError:
             pass
         except Exception as e:
-            raise f"Failed for {e}"
+            raise RuntimeError(f"Failed for {e}")
         else:
             return super()._initiate_upload()
 


### PR DESCRIPTION
AzureBlobFile._initiate_upload tried to raise a string instead of an exception.

Now raises RuntimeError