### PR TITLE
Added usage of sas_token to perform authentication

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -408,6 +408,10 @@ class AzureBlobFileSystem(AbstractFileSystem):
             self.service_client = BlobServiceClient(
                 account_url=self.account_url, credential=self.account_key
             )
+        elif self.sas_token is not None:
+            self.service_client = BlobServiceClient(
+                account_url=self.account_url + self.sas_token, credential=None
+            )
         else:
             raise ValueError("unable to connect with provided params!!")
 


### PR DESCRIPTION
This scenario will happen only when sas_token is specified and other auth parameters are
not provided (account_key, client_secret)