### PR TITLE
Fix inconsistencies for type and size/length between MS Azure API and fsspec

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -103,8 +103,8 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
         )
 
         for file in files:
-            if "type" in file and file["type"] == "DIRECTORY":
-                file["type"] = "directory"
+            if "type" in file:
+                file["type"] = file["type"].lower()
 
         return files
 
@@ -115,6 +115,8 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
             expected_error_code=expected_error_code,
         )
         info["size"] = info["length"]
+        """Azure FS uses upper case type values but fsspec is expecting lower case"""
+        info["type"] = info["type"].lower()
         return info
 
     def _trim_filename(self, fn, **kwargs):

--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -105,7 +105,8 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
         for file in files:
             if "type" in file:
                 file["type"] = file["type"].lower()
-
+            if "length" in file:
+                file["size"] = file["length"]
         return files
 
     def info(self, path, invalidate_cache=True, expected_error_code=404, **kwargs):


### PR DESCRIPTION
fsspec is expecting the `type` values `file` and `directory`, however the official MS Azure API is returning upper case values. Hence converting to lower case in `info()` and `ls()` consistently (previously only `directory` was converted).

Furthermore fsspec is expecting `size` instead of `length` used by the MS Azure API. This conversion was already done in `info()` and is now extended to `ls()` with this PR.