### PR TITLE
Remove pytest from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "azure-identity",
         "azure-storage-blob>=12.5.0",
         "fsspec>=0.8.0",
-        "pytest>=5.0,<6.0",
         "msrestazure",
         "requests>=2.22.0,<3.0",
     ],


### PR DESCRIPTION
From the discussion in #85, it should not be necessary to have pytest as part of the "install_requires" section.

Trying to avoid as many dependencies as possible in our builds - azure brings in lots of them :-)