### PR TITLE
add az protocol

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ $ conda activate adlfs-dev
 $ pip install -r dev-requirements.txt
 ```
 
-You can run tests from the main dask directory as follows:
+You can run tests from the main directory as follows:
 ```bash
 $ py.test adlfs/tests
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,17 @@
 Dask is a community maintained project. We welcome contributions in the form of bug reports, documentation, code, design proposals, and more. 
 
 For general information on how to contribute see https://docs.dask.org/en/latest/develop.html.
+
+To develop ``adlfs`` it best to work in an virtual environment.
+You can create a virtual environment using ``conda`` and install the development dependencies as follows:
+
+```bash
+$ conda create -n adlfs-dev python=3.8
+$ conda activate adlfs-dev
+$ pip install -r dev-requirements.txt
+```
+
+You can run tests from the main dask directory as follows:
+```bash
+$ py.test adlfs/tests
+```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ STORAGE_OPTIONS={'tenant_id': TENANT_ID, 'client_id': CLIENT_ID, 'client_secret'
 dd.read_csv('adl://{STORE_NAME}/{FOLDER}/*.csv', storage_options=STORAGE_OPTIONS)
 ```
 
-To use the Gen2 filesystem:
+To use the Gen2 filesystem you can use the protocol `abfs` or `az`:
 
 ```python
 import dask.dataframe as dd
@@ -33,7 +33,18 @@ import dask.dataframe as dd
 STORAGE_OPTIONS={'account_name': ACCOUNT_NAME, 'account_key': ACCOUNT_KEY}
 
 ddf = dd.read_csv('abfs://{CONTAINER}/{FOLDER}/*.csv', storage_options=STORAGE_OPTIONS)
-ddf = dd.read_parquet('abfs://{CONTAINER}/folder.parquet', storage_options=STORAGE_OPTIONS)
+ddf = dd.read_parquet('az://{CONTAINER}/folder.parquet', storage_options=STORAGE_OPTIONS)
+```
+
+To read from a public storage blob you are required to specify the `'account_name'`.
+For example, you can access [GOES-16 data](https://azure.microsoft.com/en-us/services/open-datasets/catalog/goes-16/) as:
+
+```python
+import adlfs
+
+storage_options = {'account_name': 'goes'}
+fs = adlfs.AzureBlobFileSystem(**storage_options)
+fs.ls("noaa-goes16")
 ```
 
 Details

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -519,18 +519,20 @@ def test_dask_parquet(storage):
     )
 
     dask_dataframe = dd.from_pandas(df, npartitions=1)
-    dask_dataframe.to_parquet(
-        "abfs://test/test_group.parquet",
-        storage_options=STORAGE_OPTIONS,
-        engine="pyarrow",
-    )
+    for protocol in ["abfs", "az"]:
+        dask_dataframe.to_parquet(
+            "{}://test/test_group.parquet".format(protocol),
+            storage_options=STORAGE_OPTIONS,
+            engine="pyarrow",
+        )
 
-    fs = AzureBlobFileSystem(**STORAGE_OPTIONS)
-    assert fs.ls("test/test_group.parquet") == [
-        "test/test_group.parquet/_common_metadata",
-        "test/test_group.parquet/_metadata",
-        "test/test_group.parquet/part.0.parquet",
-    ]
+        fs = AzureBlobFileSystem(**STORAGE_OPTIONS)
+        assert fs.ls("test/test_group.parquet") == [
+            "test/test_group.parquet/_common_metadata",
+            "test/test_group.parquet/_metadata",
+            "test/test_group.parquet/part.0.parquet",
+        ]
+        fs.rm("test/test_group.parquet")
 
     df_test = dd.read_parquet(
         "abfs://test/test_group.parquet",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ azure-storage-blob>=12.5.0
 azure-identity
 dask[dataframe]
 docker>=4.1.0,<5.0.0
-fsspec>=0.8.0
+fsspec>=0.8.2
 msrestazure
 pyarrow
 pytest>=5.0,<6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ azure-core>=1.5.0
 azure-datalake-store>=0.0.46,<0.1
 azure-identity
 azure-storage-blob>=12.5.0
-fsspec>=0.8.0
+fsspec>=0.8.2
 msrestazure
 requests>=2.22.0,<3.0


### PR DESCRIPTION
Closing PR https://github.com/dask/adlfs/pull/91 and opening this as was easier to rebase.

Closes issue https://github.com/dask/adlfs/issues/78 - by allowing users to use the `az://` protocol which is the same as `abfs://`.
Closes issue https://github.com/dask/adlfs/issues/89 - by adding more information to CONTRIBUTING.md
Closes issue https://github.com/dask/adlfs/issues/109 - by updating the README.md to include information on how to access public blobs

