### PR TITLE
Change "find()" of AzureBlobFileSystem to match gcsfs implementation

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -700,7 +700,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 containers = [c async for c in contents]
                 files = await self._details(containers)
                 self.dircache[path] = files
-                return files
+
             return self.dircache[path]
         else:
             if target_path not in self.dircache or invalidate_cache or return_glob:
@@ -745,22 +745,18 @@ class AzureBlobFileSystem(AsyncFileSystem):
                                             pass
                     except ResourceNotFoundError:
                         raise FileNotFoundError
+                    finalblobs = await self._details(
+                        outblobs, target_path=target_path, return_glob=return_glob
+                    )
                     if return_glob:
-                        finalblobs = await self._details(
-                            outblobs, target_path=target_path, return_glob=True
-                        )
                         return finalblobs
-                    else:
-                        finalblobs = await self._details(
-                            outblobs, target_path=target_path
-                        )
+                    finalblobs = await self._details(outblobs, target_path=target_path)
                     if not finalblobs:
                         if not await self._exists(target_path):
                             raise FileNotFoundError
-                        else:
-                            return []
+                        return []
                     self.dircache[target_path] = finalblobs
-                    return finalblobs
+
             return self.dircache[target_path]
 
     async def _details(

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -412,6 +412,52 @@ def test_find(storage):
     ## missing
     assert fs.find("data/missing") == []
 
+    ## prefix search
+    assert fs.find("data/root", prefix="a") == [
+        "data/root/a/file.txt",
+        "data/root/a1/file1.txt",
+    ]
+
+    assert fs.find("data/root", prefix="a", withdirs=True) == [
+        "data/root/a",
+        "data/root/a/file.txt",
+        "data/root/a1",
+        "data/root/a1/file1.txt",
+    ]
+
+    find_results = fs.find("data/root", prefix="a1", withdirs=True, detail=True)
+    assert_blobs_equals(
+        list(find_results.values()),
+        [
+            {"name": "data/root/a1", "size": 0, "type": "directory"},
+            {
+                "name": "data/root/a1/file1.txt",
+                "size": 10,
+                "type": "file",
+                "archive_status": None,
+                "deleted": None,
+                "creation_time": storage.insert_time,
+                "last_modified": storage.insert_time,
+                "deleted_time": None,
+                "last_accessed_on": None,
+                "remaining_retention_days": None,
+                "tag_count": None,
+                "tags": None,
+                "metadata": {},
+                "content_settings": {
+                    "content_type": "application/octet-stream",
+                    "content_encoding": None,
+                    "content_language": None,
+                    "content_md5": bytearray(
+                        b"x\x1e^$]i\xb5f\x97\x9b\x86\xe2\x8d#\xf2\xc7"
+                    ),
+                    "content_disposition": None,
+                    "cache_control": None,
+                },
+            },
+        ],
+    )
+
 
 # @pytest.mark.xfail
 def test_find_missing(storage):


### PR DESCRIPTION
Previously the find would take a path and recursively list all the
sub folders until maxdepth(default to None) is reached, this was mostly
used by glob().

This changes the behavior to the following one:

Take a path (a directory) and a prefix (partial match)
and list ervery blob that matches "^{path}/{prefix}*"
This is done in one single API call, no recursions.
The `maxdepth` argument of "find" has been dropped since it doesn't have
any meaning now all the matching blobs will be returned.

It suffers the same 'bug' regarding withdirs kwargs:

  The following structure might bring wrong dir results:
    - directory_a/a/b/c/file.txt
  when querying path: `directory_a` prefix: `a` and withsubdirs
  only directory_a/b/c will be returned as a directory which means
  that only folder with a file will be returned, Reading the from
  gcsfs, it looks like this is normal behavior.
  It might not be considered a bug thou

The glob function behavior however remains unchanged since this is the
only way we can do proper complex pattern matching with branch elimination
which might, for some, be useful.


https://github.com/dask/adlfs/commit/b490a8cbc637dc6547c69fb29c8abb5a414a536a introduces a breaking change let me know if you have any annotation / process when the api breaks

Fixes #152 