### PR TITLE
BUG: Handle empty writes for large files

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1615,10 +1615,17 @@ class AzureBlobFile(io.IOBase):
                 # This step handles the situation where data="" and length=0
                 # which is throws an InvalidHeader error from Azure, so instead
                 # of staging a block, we directly upload the empty blob
+                # This isn't actually tested, since Azureite behaves differently.
                 if block_id == "0000000" and length == 0 and final:
                     self.blob_client.upload_blob(data=data, metadata=self.metadata)
+                elif length == 0 and final:
+                    # just finalize
+                    block_list = [BlobBlock(_id) for _id in self._block_list]
+                    self.blob_client.commit_block_list(
+                        block_list=block_list, metadata=self.metadata
+                    )
                 else:
-                    raise RuntimeError(f"Failed to upload block with {e}!!")
+                    raise RuntimeError(f"Failed to upload block{e}!") from e
         elif self.mode == "ab":
             self.blob_client.upload_blob(
                 data=data,


### PR DESCRIPTION
Closes https://github.com/dask/adlfs/issues/154

No new tests here. We already have one that intends to catch this behavior `test_large_blob`. Unfortunately it didn't catch the issue since azurite doesn't raise the exception when trying to write an empty block. I've manually verified that the result matches, but it'd be nice to have someone check my logic.

cc @hayesgb