### PR TITLE
PERF: Improve performance of exists

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1138,12 +1138,14 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 return True
         except FileNotFoundError:
             pass
-        try:
-            await self._info(path)
-            return True
-        except:  # noqa: E722
-            # any exception allowed bar FileNotFoundError?
-            return False
+
+        container_name, path = self.split_path(path)
+        cc = self.service_client.get_container_client(container_name)
+        bc = cc.get_blob_client(blob=path)
+        async with bc:
+            exists = await bc.exists()
+
+        return exists
 
     def cat(self, path, recursive=False, on_error="raise", **kwargs):
         """Fetch (potentially multiple) paths' contents

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1140,6 +1140,11 @@ class AzureBlobFileSystem(AsyncFileSystem):
             pass
 
         container_name, path = self.split_path(path)
+
+        if not path:
+            # Empty paths exist by definition
+            return True
+
         cc = self.service_client.get_container_client(container_name)
         bc = cc.get_blob_client(blob=path)
         async with bc:

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1024,3 +1024,15 @@ def test_cp_file(storage):
     assert "homedir/enddir/test_file.txt" in files
 
     fs.rm("homedir", recursive=True)
+
+
+def test_exists(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+
+    assert fs.exists("data/top_file.txt")
+    assert fs.exists("data")
+    assert fs.exists("data/")
+    assert fs.exists("")
+    assert not fs.exists("data/not-a-key")


### PR DESCRIPTION
Closes https://github.com/dask/adlfs/issues/156.

There is a slight behavior change here. Since we aren't going through
`ls`, we don't cache that this file exists anymore. I *think* that's
probably OK, but we may be able to cache it (assuming the BlobClient
has all the information we need).