### PR TITLE
fix memory leak azure file

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1519,7 +1519,6 @@ class AzureBlobFile(AbstractBufferedFile):
             cache_options["trim"] = kwargs.pop("trim")
         self.metadata = None
         self.kwargs = kwargs
-        weakref.finalize(self, maybe_sync, self.container_client.close, self)
 
         if self.mode not in {"ab", "rb", "wb"}:
             raise NotImplementedError("File mode not supported")
@@ -1536,6 +1535,11 @@ class AzureBlobFile(AbstractBufferedFile):
             self.offset = None
             self.forced = False
             self.location = None
+
+    def close(self):
+        """Close file and azure client."""
+        maybe_sync(self.container_client.close, self)
+        super().close()
 
     def connect_client(self):
         """Connect to the Synchronous BlobServiceClient, using user-specified connection details.

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -565,7 +565,7 @@ def test_glob(storage):
     assert fs.glob("data/missing/*") == []
 
 
-def test_open_file(storage):
+def test_open_file(storage, mocker):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR
     )
@@ -573,6 +573,23 @@ def test_open_file(storage):
 
     result = f.read()
     assert result == b"0123456789"
+
+    close = mocker.patch.object(f.container_client, "close")
+    f.close()
+
+    close.assert_called_once()
+
+def test_open_context_manager(storage, mocker):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    with fs.open("/data/root/a/file.txt") as f:
+        close = mocker.patch.object(f.container_client, "close")
+        result = f.read()
+        assert result == b"0123456789"
+
+    close.assert_called_once()
+
 
 
 def test_rm(storage):

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -579,7 +579,9 @@ def test_open_file(storage, mocker):
 
     close.assert_called_once()
 
+
 def test_open_context_manager(storage, mocker):
+    "test closing azure client with context manager"
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR
     )
@@ -589,7 +591,6 @@ def test_open_context_manager(storage, mocker):
         assert result == b"0123456789"
 
     close.assert_called_once()
-
 
 
 def test_rm(storage):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,6 +11,7 @@ pyarrow
 pytest>=5.0,<6.0
 pytest-asyncio
 pytest-cov
+pytest-mock
 requests>=2.22.0,<3.0
 scipy>=0.9
 versioneer>=0.18,<1.0


### PR DESCRIPTION
adfls causes unbounded memory allocation when adding mutliple files (or same file many times).

Here is some code to reproduce it:

```
import adlfs

data = b"0123456"
bucket_name = "testleak"

account_name = "..."
account_access_key = "..."
conn_str = "..."

fs = adlfs.AzureBlobFileSystem(account_name=account_name, connection_string=conn_str)

while True:
    with fs.open(bucket_name + "/test_file.bin", 'wb') as f:
        f.write(data)
```

which produces this linear allocated memory size:

![simple_adlfs](https://user-images.githubusercontent.com/41565/107251430-9d9ba900-6a34-11eb-85fa-9605484970f0.png)


This is related to weakref.finalize call that will keep the references of the AzureBlobFile object. According to python docs:

> Note: It is important to ensure that func, args and kwargs do not own any references to obj, either directly or indirectly, since otherwise obj will never be garbage collected. In particular, func should not be a bound method of obj. 

https://docs.python.org/3/library/weakref.html#weakref.finalize

The close function can be called explicitly or in a context manager as shown in tests.