### PR TITLE
When connecting preserve a reference for the underlying issue

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1590,7 +1590,7 @@ class AzureBlobFile(AbstractBufferedFile):
         except Exception as e:
             raise ValueError(
                 f"Unable to fetch container_client with provided params for {e}!!"
-            )
+            ) from e
 
     async def _async_fetch_range(self, start: int, end: int, **kwargs):
         """


### PR DESCRIPTION
For people who might want to print a pretty message according to the underlying cause (like a network error, authorization error etc) it is useful to keep a reference (in `__cause__`). 