### PR TITLE
Proper folder handling

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1216,6 +1216,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         except FileNotFoundError:
             pass
 
+        full_path = path
         container_name, path = self.split_path(path)
 
         if not path:
@@ -1227,7 +1228,11 @@ class AzureBlobFileSystem(AsyncFileSystem):
         async with bc:
             exists = await bc.exists()
 
-        return exists
+        # If the blob doesn't exist with the given name
+        # and if we can't retrieve it from the cache
+        # we'll call info() to see whether it actually
+        # exists or not.
+        return exists or super().exists(full_path)
 
     async def _pipe_file(self, path, value, overwrite=True, **kwargs):
         """Set the bytes of given file"""

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1165,3 +1165,18 @@ def test_exists(storage):
     assert fs.exists("data/")
     assert fs.exists("")
     assert not fs.exists("data/not-a-key")
+
+
+def test_exists_directory(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    fs.mkdir("homedir")
+    fs.touch("homedir/dir/foo")
+    fs.touch("homedir/dir/bar")
+
+    fs.invalidate_cache()
+    assert fs.exists("homedir/dir")
+    assert fs.isdir("homedir/dir")
+
+    fs.rm("homedir", recursive=True)


### PR DESCRIPTION
Here is a simple demonstration of what I've been trying to solve;
```py
import secrets
from adlfs import AzureBlobFileSystem

BUCKET = 'test-8/'
FOLDER = f'test-8/{secrets.token_hex(12)}/'

fs = AzureBlobFileSystem(account_name=_NAME, account_key=_KEY)
fs.touch(FOLDER + 'foo')
fs.touch(FOLDER + 'bar')
fs.invalidate_cache()

fs = AzureBlobFileSystem(account_name=_NAME, account_key=_KEY)
print(fs.exists(FOLDER))
print(FOLDER in fs.ls(fs._parent(FOLDER)))
```
The `exists()` calls results with False even though it is a folder (can be shown by the next call). There are some places in the code which should clear trailing slash when passing (to use with `_ls_from_cache`) and also `.exists()` need to fall back to `.info()` in the case of cache being empty and the searched thing is not a file but rather a directory. So when fall backed into `super().exists()` which wraps `.info()` under the hood which searches for this directory. 