### PR TITLE
Fallback for azure identity default authentication #201

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ ddf = dd.read_parquet('az://{CONTAINER}/folder.parquet', storage_options=storage
 
 or optionally, if AZURE_STORAGE_ACCOUNT_NAME and an AZURE_STORAGE_<CREDENTIAL> is 
 set as an environmental variable, then storage_options will be read from the environmental
-variables
+variables. In case none of them is specified, it will fall back to the azure identity library [default authentication methods](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential)
+
 ```
 
 To read from a public storage blob you are required to specify the `'account_name'`.

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -346,6 +346,11 @@ class AzureBlobFileSystem(AsyncFileSystem):
         ...    client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
     >>> abfs.ls('')
 
+    Authentication with environment based identity which can be  EnvironmentCredential, ManagedIdentityCredential,
+    SharedTokenCache(Windows only), AzureCLI identity
+    >>> abfs = AzureBlobFileSystem(account_name="XXXX", tenant_id=TENANT_ID)
+
+
     **  Read files as: **
         -------------
         ddf = dd.read_csv('abfs://container_name/folder/*.csv', storage_options={
@@ -400,12 +405,17 @@ class AzureBlobFileSystem(AsyncFileSystem):
             self.credential is None
             and self.account_key is None
             and self.sas_token is None
-            and self.client_id is not None
         ):
-            (
-                self.credential,
-                self.sync_credential,
-            ) = self._get_credential_from_service_principal()
+            if(self.client_id is not None):
+                (
+                    self.credential,
+                    self.sync_credential,
+                ) = self._get_credential_from_service_principal()
+            else:
+                (
+                    self.credential,
+                    self.sync_credential,
+                ) = self._get_default_credential()
         else:
             self.sync_credential = None
         self.do_connect()
@@ -467,9 +477,26 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
         return (async_credential, sync_credential)
 
+    def _get_default_credential(self):
+        """
+        Use azure identity default credential resolver method. This is useful both for local development
+        (eg. to use VS Code token cache) and on Azure by using managed identity. 
+        https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential
+
+        Returns
+        -------
+        Tuple of (Async Credential, Sync Credential).
+        """
+        from azure.identity import DefaultAzureCredential
+        from azure.identity.aio import (
+            DefaultAzureCredential as AIODefaultAzureCredential,
+        )
+        return (AIODefaultAzureCredential(), DefaultAzureCredential())
+
+
     def do_connect(self):
         """Connect to the BlobServiceClient, using user-specified connection details.
-        Tries credentials first, then connection string and finally account key
+        Tries credentials first, then connection string and finally account key.
 
         Raises
         ------

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -480,7 +480,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
     def _get_default_credential(self):
         """
         Use azure identity default credential resolver method. This is useful both for local development
-        (eg. to use VS Code token cache) and on Azure by using managed identity. 
+        (eg. to use VS Code token cache) and on Azure by using managed identity.
         https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential
 
         Returns

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -406,7 +406,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
             and self.account_key is None
             and self.sas_token is None
         ):
-            if(self.client_id is not None):
+            if self.client_id is not None:
                 (
                     self.credential,
                     self.sync_credential,
@@ -491,8 +491,8 @@ class AzureBlobFileSystem(AsyncFileSystem):
         from azure.identity.aio import (
             DefaultAzureCredential as AIODefaultAzureCredential,
         )
-        return (AIODefaultAzureCredential(), DefaultAzureCredential())
 
+        return (AIODefaultAzureCredential(), DefaultAzureCredential())
 
     def do_connect(self):
         """Connect to the BlobServiceClient, using user-specified connection details.


### PR DESCRIPTION
Methods implementation and readme update. #201 
The main goal of this would be to support Azure Managed Identities for credential free authentication.
This could be really useful for local development too as it allows to  pull Azure CLI and VSCode tokens

This is my first PR and I would be happy to get feedbacks.
Thanks!