### PR TITLE
Haneld the situation that Azure Datalake Gen1 returns filename

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -140,7 +140,7 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
             path=path, detail=detail, invalidate_cache=invalidate_cache
         )
 
-        for file in files:
+        for file in (file for file in files if type(file) is dict):
             if "type" in file:
                 file["type"] = file["type"].lower()
             if "length" in file:


### PR DESCRIPTION
contains special sub-string

AzureDatalakeFileSystem.ls has special mechanism for type and length.
But the above special mechanism should only applicable when call ls
with detail=True and ls returns a list of dictionary.

When call ls with detail=False, it returns a list of str. Keyword in
for str has the meaning of check if one str is substring of another.
That is not what the mechanism should acting on.

Closes #227