### PR TITLE
Fix bug for filter_blobs when target_path contains special character …

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -881,7 +881,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
             if len(output) == 1 and output[0]["type"] == "file":
                 # This handles the case where path is a file passed to ls
                 return output
-            output = await filter_blobs(output, target_path)
+            output = await filter_blobs(output, target_path, delimiter)
 
         return output
 

--- a/adlfs/tests/conftest.py
+++ b/adlfs/tests/conftest.py
@@ -53,6 +53,8 @@ def storage(host):
     container_client.upload_blob(
         "root/d/file_with_metadata.txt", data, metadata=metadata
     )
+    container_client.upload_blob("root/e+f/file1.txt", data)
+    container_client.upload_blob("root/e+f/file2.txt", data)
     yield bbs
 
 

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -110,8 +110,14 @@ def test_ls(storage):
     assert fs.ls("data/root/b/") == ["data/root/b/file.txt"]
     assert fs.ls("data/root/a1") == ["data/root/a1/file1.txt"]
     assert fs.ls("data/root/a1/") == ["data/root/a1/file1.txt"]
-    assert fs.ls("data/root/e+f") == ["data/root/e+f/file1.txt", "data/root/e+f/file2.txt"]
-    assert fs.ls("data/root/e+f/") == ["data/root/e+f/file1.txt", "data/root/e+f/file2.txt"]
+    assert fs.ls("data/root/e+f") == [
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
+    ]
+    assert fs.ls("data/root/e+f/") == [
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
+    ]
 
     ## file details
     files = fs.ls("data/root/a/file.txt", detail=True)

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -88,6 +88,7 @@ def test_ls(storage):
         "data/root/b",
         "data/root/c",
         "data/root/d",
+        "data/root/e+f",
         "data/root/rfile.txt",
     ]
     assert fs.ls("data/root/") == [
@@ -96,6 +97,7 @@ def test_ls(storage):
         "data/root/b",
         "data/root/c",
         "data/root/d",
+        "data/root/e+f",
         "data/root/rfile.txt",
     ]
 
@@ -108,6 +110,8 @@ def test_ls(storage):
     assert fs.ls("data/root/b/") == ["data/root/b/file.txt"]
     assert fs.ls("data/root/a1") == ["data/root/a1/file1.txt"]
     assert fs.ls("data/root/a1/") == ["data/root/a1/file1.txt"]
+    assert fs.ls("data/root/e+f") == ["data/root/e+f/file1.txt", "data/root/e+f/file2.txt"]
+    assert fs.ls("data/root/e+f/") == ["data/root/e+f/file1.txt", "data/root/e+f/file2.txt"]
 
     ## file details
     files = fs.ls("data/root/a/file.txt", detail=True)
@@ -356,6 +360,8 @@ def test_find(storage):
         "data/root/c/file1.txt",
         "data/root/c/file2.txt",
         "data/root/d/file_with_metadata.txt",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
         "data/root/rfile.txt",
     ]
     assert fs.find("data/root", withdirs=False) == [
@@ -365,6 +371,8 @@ def test_find(storage):
         "data/root/c/file1.txt",
         "data/root/c/file2.txt",
         "data/root/d/file_with_metadata.txt",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
         "data/root/rfile.txt",
     ]
 
@@ -381,6 +389,9 @@ def test_find(storage):
         "data/root/c/file2.txt",
         "data/root/d/",
         "data/root/d/file_with_metadata.txt",
+        "data/root/e+f/",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
         "data/root/rfile.txt",
     ]
     assert fs.find("data/root/", withdirs=True) == [
@@ -395,6 +406,9 @@ def test_find(storage):
         "data/root/c/file2.txt",
         "data/root/d/",
         "data/root/d/file_with_metadata.txt",
+        "data/root/e+f/",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
         "data/root/rfile.txt",
     ]
 
@@ -470,6 +484,7 @@ def test_glob(storage):
         "data/root/b",
         "data/root/c",
         "data/root/d",
+        "data/root/e+f",
         "data/root/rfile.txt",
     ]
     assert fs.glob("data/root/*") == [
@@ -478,6 +493,7 @@ def test_glob(storage):
         "data/root/b",
         "data/root/c",
         "data/root/d",
+        "data/root/e+f",
         "data/root/rfile.txt",
     ]
 
@@ -495,6 +511,8 @@ def test_glob(storage):
         "data/root/a1/file1.txt",
         "data/root/c/file1.txt",
         "data/root/c/file2.txt",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
     ]
 
     ## text files
@@ -505,6 +523,8 @@ def test_glob(storage):
         "data/root/c/file1.txt",
         "data/root/c/file2.txt",
         "data/root/d/file_with_metadata.txt",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
     ]
 
     ## all text files
@@ -515,6 +535,8 @@ def test_glob(storage):
         "data/root/c/file1.txt",
         "data/root/c/file2.txt",
         "data/root/d/file_with_metadata.txt",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
         "data/root/rfile.txt",
     ]
 
@@ -531,6 +553,9 @@ def test_glob(storage):
         "data/root/c/file2.txt",
         "data/root/d",
         "data/root/d/file_with_metadata.txt",
+        "data/root/e+f",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
         "data/root/rfile.txt",
     ]
     assert fs.glob("data/roo**") == [
@@ -546,6 +571,9 @@ def test_glob(storage):
         "data/root/c/file2.txt",
         "data/root/d",
         "data/root/d/file_with_metadata.txt",
+        "data/root/e+f",
+        "data/root/e+f/file1.txt",
+        "data/root/e+f/file2.txt",
         "data/root/rfile.txt",
     ]
 

--- a/adlfs/utils.py
+++ b/adlfs/utils.py
@@ -12,9 +12,9 @@ async def filter_blobs(blobs, target_path, delimiter="/"):
             Delimiter used to separate containers and files
     """
     # remove delimiter and spaces, then add delimiter at the end
-    target_path = target_path.strip(" "+delimiter)+delimiter
+    target_path = target_path.strip(" " + delimiter) + delimiter
     finalblobs = [
-        b for b in blobs if b["name"].strip(" "+delimiter).startswith(target_path)
+        b for b in blobs if b["name"].strip(" " + delimiter).startswith(target_path)
     ]
     return finalblobs
 

--- a/adlfs/utils.py
+++ b/adlfs/utils.py
@@ -14,7 +14,7 @@ async def filter_blobs(blobs, target_path, delimiter="/"):
     # remove delimiter and spaces, then add delimiter at the end
     target_path = target_path.strip(" "+delimiter)+delimiter
     finalblobs = [
-        b for b in blobs if b["name"].strip(" /").startswith(target_path)
+        b for b in blobs if b["name"].strip(" "+delimiter).startswith(target_path)
     ]
     return finalblobs
 

--- a/adlfs/utils.py
+++ b/adlfs/utils.py
@@ -1,7 +1,4 @@
-import re
-
-
-async def filter_blobs(blobs, target_path):
+async def filter_blobs(blobs, target_path, delimiter="/"):
     """
     Filters out blobs that do not come from target_path
 
@@ -10,9 +7,14 @@ async def filter_blobs(blobs, target_path):
     blobs:  A list of candidate blobs to be returned from Azure
 
     target_path: Actual prefix of the blob folder
+
+    delimiter: str
+            Delimiter used to separate containers and files
     """
+    # remove delimiter and spaces, then add delimiter at the end
+    target_path = target_path.strip(" "+delimiter)+delimiter
     finalblobs = [
-        b for b in blobs if re.search(r"\b" + target_path + r"(?=/)" + r"\b", b["name"])
+        b for b in blobs if b["name"].strip(" /").startswith(target_path)
     ]
     return finalblobs
 


### PR DESCRIPTION
Fix bug for filter_blobs when target_path contains special character for regex

Use str.startswith to check if a blob is come from target_path.
Maybe use regex is a bit overhead for this case.

Add the test case when the path has + as part of path, which also explains what is the situation.
The test case won't pass without this PR.

Closes #231 