### PR TITLE
Implement rm_file and rmdir for AzureDatalakeFileSystem

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -206,6 +206,14 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
     def size(self, path):
         return self.info(path)["length"]
 
+    def rmdir(self, path):
+        """Remove a directory, if empty"""
+        self.azure_fs.rmdir(path)
+
+    def rm_file(self, path):
+        """Delete a file"""
+        self.azure_fs.rm(path)
+
     def __getstate__(self):
         dic = self.__dict__.copy()
         logger.debug("Serialize with state: %s", dic)


### PR DESCRIPTION
Implement rmdir and rm_file for AzureDatalakeFileSystem

No need to implement rm method, it will use AbstractFileSystem's implementation and end up to rm_file.

#233