### PR TITLE
spec: support exists() on directories pre-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 **Change Log**
+v0.7.5
+------
+- `exists()` calls now also checks whether a directory with that name exists or not. Previously this was only checked from the cache.
+
 v0.7.4
 ------
 - Added the location_mode parameter to AzureBlobFileSystem object, and set default to "primary" to enable Access Control Lists and RA-GRS access.  Valid values are "primary" and "secondary"

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1275,8 +1275,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         except KeyError:
             pass
 
-        full_path = self._strip_protocol(path)
-        container_name, path = self.split_path(full_path)
+        container_name, path = self.split_path(path)
 
         if not path:
             if container_name:

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1293,7 +1293,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
         async with self.service_client.get_container_client(
             container=container_name
         ) as container_client:
-            async for blob in container_client.list_blobs(name_starts_with=dir_path):
+            async for blob in container_client.list_blobs(
+                results_per_page=1, name_starts_with=dir_path
+            ):
                 return True
             else:
                 return False

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1289,7 +1289,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
             if await bc.exists():
                 return True
 
-        dir_path = path.lstrip("/") + "/"
+        dir_path = path.rstrip("/") + "/"
         async with self.service_client.get_container_client(
             container=container_name
         ) as container_client:

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1275,6 +1275,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         except KeyError:
             pass
 
+        full_path = path
         container_name, path = self.split_path(path)
 
         if not path:
@@ -1286,7 +1287,8 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
         async with self.service_client.get_blob_client(container_name, path) as bc:
             exists = await bc.exists()
-        return exists
+
+        return exists or await super()._exists(full_path)
 
     async def _pipe_file(self, path, value, overwrite=True, **kwargs):
         """Set the bytes of given file"""

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1206,3 +1206,21 @@ def test_exists(storage):
     assert not fs.exists("non-existent-container/")
     assert fs.exists("")
     assert not fs.exists("data/not-a-key")
+
+
+def test_exists_directory(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+
+    fs.mkdir("temp_exists")
+    fs.touch("temp_exists/data/data.txt")
+    fs.touch("temp_exists/data/something/data.txt")
+    fs.invalidate_cache()
+
+    assert fs.exists("temp_exists/data/something/")
+    assert fs.exists("temp_exists/data/something")
+    assert fs.exists("temp_exists/data/")
+    assert fs.exists("temp_exists/data")
+    assert fs.exists("temp_exists/")
+    assert fs.exists("temp_exists")


### PR DESCRIPTION
```
import secrets
from adlfs import AzureBlobFileSystem

BUCKET = 'bucket/'
FOLDER = f'{BUCKET}{secrets.token_hex(12)}/'

fs = AzureBlobFileSystem(**opts)
fs.touch(FOLDER + 'foo')
fs.touch(FOLDER + 'bar')
fs.invalidate_cache()

print(fs.exists(FOLDER))
fs.ls(fs._parent(FOLDER))
print(fs.exists(FOLDER))
```

While the first one is returning False, after the cache the second one is returning true. The reason is that, the `exists()` implementation first tries to check whether a such a directory exists by traversing the cache and when it fails it tries to check if a blob named `path` exists though if the directory is not cached, it doesn't check for that. This patch makes it fallback to the default implementation which is basically checking the result of `info()`. 