### PR TITLE
Enable DefaultAzureCredential with kw anon=False and no explicit credentials provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 **Change Log**
+v2021.08.1
+------
+- Added DefaultAzureCredential as an authentication method.  Activated if anon is False, and
+  no explicit credentials are passed.  See authentication methods enabled [here](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python). 
+
 v0.7.7
 ------
 - Fixed bug in fetch_range that caused attempted reads beyond end of file

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Operations against the Gen2 Datalake are implemented by leveraging [Azure Blob S
         sas_token
         connection_string
         Azure ServicePrincipal credentials (which requires tenant_id, client_id, client_secret)
+        anon
         location_mode:  valid value are "primary" or "secondary" and apply to RA-GRS accounts
 
     The following enviornmental variables can also be set and picked up for authentication:
@@ -82,6 +83,13 @@ Operations against the Gen2 Datalake are implemented by leveraging [Azure Blob S
         "AZURE_STORAGE_CLIENT_SECRET"
         "AZURE_STORAGE_CLIENT_ID"
         "AZURE_STORAGE_TENANT_ID"
+
+    The default value for anon (anonymous) is True.  If no explicit credentials are set, the
+    AzureBlobFileSystem will assume the account_name points to a public container, and attempt to use an anonymous login.
+
+    If anon (anonymous) is False, AzureBlobFileSystem will attempt to authenticate using Azure's 
+    DefaultAzureCredential() library.  Specifics of the types of authentication permitted can be
+    found [here](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-pythonhttps://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python)
 
 
 The AzureBlobFileSystem accepts [all of the Async BlobServiceClient arguments](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python).

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -359,6 +359,10 @@ class AzureBlobFileSystem(AsyncFileSystem):
         ...    client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
     >>> abfs.ls('')
 
+    Authentication with DefaultAzureCredential
+    >>> abfs = AzureBlobFileSystem(account_name="XXXX", anon=False)
+    >>> abfs.ls('')
+
     **  Read files as: **
         -------------
         ddf = dd.read_csv('abfs://container_name/folder/*.csv', storage_options={


### PR DESCRIPTION
Tagging @isidentical @dylanfprice and @rhjmoore in this PR

This is intended to enable use of DefaultAzureCredential, with an anon parameter.

Based on #254  #226 #201 

in this PR, the default value of anon is set to TRUE, so behavior the default behavior if no credentials are explicitly provided will be to attempt to login to a public account.  If no explicit credentials are provided, and `anon=False` then it should attempt to pull credentials using `DefaultAzureCredential`

It would be great to get feedback on this, since I know there's been interest.  