### PR TITLE
Allow write without delete priveleges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v2021.08.1
 - Updated unit test for isdir
 - Added DefaultAzureCredential as an authentication method.  Activated if anon is False, and
   no explicit credentials are passed.  See authentication methods enabled [here](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python). 
+- Updated initiate_upload() method to allow overwriting a blob if the credentials do not have delete priveleges.  
 
 v0.7.7
 ------

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -13,6 +13,7 @@ import weakref
 
 from azure.core.exceptions import (
     ClientAuthenticationError,
+    HttpResponseError,
     ResourceNotFoundError,
     ResourceExistsError,
 )
@@ -1877,6 +1878,8 @@ class AzureBlobFile(AbstractBufferedFile):
             try:
                 await self.container_client.delete_blob(self.blob)
             except ResourceNotFoundError:
+                pass
+            except HttpResponseError:
                 pass
             else:
                 await self._reinitiate_async_upload()


### PR DESCRIPTION
Previously, adlfs required the credentials being used to have delete rights in the container.  This enables overwriting a blob without delete rights.