### PR TITLE
Implement support for fsspec callbacks in put_file/get_file

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1525,7 +1525,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
             raise FileNotFoundError
         return list(sorted(out))
 
-    async def _put_file(self, lpath, rpath, delimiter="/", overwrite=False, **kwargws):
+    async def _put_file(
+        self, lpath, rpath, delimiter="/", overwrite=False, callback=None, **kwargws
+    ):
         """
         Copy single file to remote
 
@@ -1546,7 +1548,12 @@ class AzureBlobFileSystem(AsyncFileSystem):
                         container_name, path
                     ) as bc:
                         await bc.upload_blob(
-                            f1, overwrite=overwrite, metadata={"is_directory": "false"}
+                            f1,
+                            overwrite=overwrite,
+                            metadata={"is_directory": "false"},
+                            raw_response_hook=make_callback(
+                                "upload_stream_current", callback
+                            ),
                         )
                 self.invalidate_cache()
             except ResourceExistsError:


### PR DESCRIPTION
This patch adds support for [fsspec callbacks](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.callbacks.Callback). It also removes some load from the `get_file`:
- There is a completely redundant `ls()` call it is making on every `get_file` operation, which is very costful
- It also tries to do an `isdir()` check, which is also very costful (if not cached) when considering it is done for every `get_file` especially on Azure, since there are no directories per se.  

Resolves #276