### PR TITLE
Add support for hdi_isfolder metadata

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -942,6 +942,12 @@ class AzureBlobFileSystem(AsyncFileSystem):
                         and data["metadata"]["is_directory"] == "false"
                     ):
                         data.update({"type": "file"})
+                    elif (
+                        "hdi_isfolder" in data["metadata"].keys()
+                        and data["metadata"]["hdi_isfolder"] == "true"
+                    ):
+                        data.update({"type": "directory"})
+                        data.update({"size": None})
                     else:
                         pass
             if return_glob:


### PR DESCRIPTION
This seems to be required to support HNS in Azure Blob (DataLake Gen2). Otherwise, `fs.find(path)` will return files and folders instead of only files and break multi-level Hive partitioned tables in pyarrow